### PR TITLE
Replace harmony-collections with es6-weak-map

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "homepage": "http://atom.github.io/property-accessors/",
   "dependencies": {
     "mixto": "1.x",
-    "harmony-collections": "git+https://github.com/Benvie/harmony-collections.git#e81b4b808359e2def9eeeabfdee69c2989e1fe96"
+    "es6-weak-map": "^0.1.2"
   },
   "devDependencies": {
     "jasmine-focused": "1.x",

--- a/src/property-accessors.coffee
+++ b/src/property-accessors.coffee
@@ -1,5 +1,5 @@
 Mixin = require 'mixto'
-WeakMap = global.WeakMap ? require('harmony-collections').WeakMap
+WeakMap = require 'es6-weak-map'
 
 module.exports =
 class PropertyAccessors extends Mixin


### PR DESCRIPTION
As you do not need everything in harmony-collections, but WeekMap only it is better to use standalone polyfill. In addition, nobody maintains harmony-collections anymore (I guess).

As, this package is used ing `emissary` and `emissary` is used in Meteor, harmony-collections is incompatible with traceur and we (people who use traceur and meteor together) are suffering right now. Here is the issue. https://github.com/mquandalle/meteor-harmony/issues/37#issuecomment-73725823
